### PR TITLE
Add methods "Pi.read" and "_callback_handler.remove"

### DIFF
--- a/apigpio/apigpio.py
+++ b/apigpio/apigpio.py
@@ -492,9 +492,10 @@ class Callback:
         self.callb = _callback_ADT(user_gpio, edge, func)
         # FIXME yield from self._notify.append(self.callb)
 
+    @asyncio.coroutine
     def cancel(self):
         """Cancels a callback by removing it from the notification thread."""
-        self._notify.remove(self.callb)
+        yield from self._notify.remove(self.callb)
 
     def _tally(self, user_gpio, level, tick):
         """Increment the callback called count."""


### PR DESCRIPTION
Before this changes, trying to cancel a callback would raise an exception (because the "remove" method of the "_callback_handler" class wasn't implemented. This also makes "Callback.cancel" a coroutine.

Also, I implemented the "Pi.read" method. Was there any reason to not implement it?