### PR TITLE
Remove deprecated asyncio.async

### DIFF
--- a/apigpio/apigpio.py
+++ b/apigpio/apigpio.py
@@ -387,7 +387,7 @@ class _callback_handler(object):
         # TODO: handle connection errors !
         yield from self._loop.sock_connect(self.s, address)
         self.handle = yield from self._pigpio_aio_command(_PI_CMD_NOIB, 0, 0)
-        asyncio.async(self._wait_for_notif())
+        asyncio.ensure_future(self._wait_for_notif(), loop=self._loop)
 
     @asyncio.coroutine
     def close(self):


### PR DESCRIPTION
Fix #13 in Python 3.7